### PR TITLE
Data transfer improvements

### DIFF
--- a/apps/PrivateEye/!PrivatEye/Resources/UK/Messages
+++ b/apps/PrivateEye/!PrivatEye/Resources/UK/Messages
@@ -165,6 +165,8 @@ error.buffer.start:Buffer failed to start. Probably out of memory.
 
 error.ffg.died:FFG translator died.
 
+error.dataxfer.scrap:Scrap transfer filename wasn't '<Wimp$Scrap>' as expected but instead '%s'. Will not delete.
+
 error.name.missing:Missing name.
 
 # Interactive Help

--- a/apps/PrivateEye/!PrivatEye/Resources/UK/Messages
+++ b/apps/PrivateEye/!PrivatEye/Resources/UK/Messages
@@ -7,6 +7,9 @@ version:3.14 (xx Aug 2022)
 task:PrivateEye
 icon:!privateye
 
+untitled.title:<untitled>
+untitled.filename:ImageFile
+
 workspace.image:PrivateEye images
 
 # Menus

--- a/apps/PrivateEye/!PrivatEye/clipboard.c
+++ b/apps/PrivateEye/!PrivatEye/clipboard.c
@@ -70,6 +70,8 @@ static int message_claim_entity(wimp_message *message, void *handle)
 
 static int message_data_request(wimp_message *message, void *handle)
 {
+#define data_request_END_OF_LIST (0xFFFFFFFFu)
+
   bits          file_type;
   bits         *types_list;
   wimp_message  datasave;
@@ -90,35 +92,36 @@ static int message_data_request(wimp_message *message, void *handle)
 
   /* If the file type is in the list, or if the list is empty, then send. */
 
-  for (i = 0; types_list[i] != file_type && types_list[i] != 0xffffffffu; i++)
+  for (i = 0; types_list[i] != file_type && types_list[i] != data_request_END_OF_LIST; i++)
     ;
+  if (types_list[0] != data_request_END_OF_LIST && types_list[i] != file_type)
+    return event_HANDLED;
 
-  if (types_list[0] == 0xffffffffu || types_list[i] == file_type)
-  {
-    /* They requested a format we can provide. Respond with a DataSave. */
+  /* They requested a format we can provide. Respond with a Message_DataSave. */
 
-    datasave.data.data_xfer.w         = message->data.data_xfer.w;
-    datasave.data.data_xfer.i         = message->data.data_xfer.i;
-    datasave.data.data_xfer.pos.x     = message->data.data_xfer.pos.x;
-    datasave.data.data_xfer.pos.y     = message->data.data_xfer.pos.y;
-    datasave.data.data_xfer.est_size  = GLOBALS.clipboard_viewer->drawable->image->display.file_size;
-    datasave.data.data_xfer.file_type = file_type;
-    strcpy(datasave.data.data_xfer.file_name,
-        str_leaf(GLOBALS.clipboard_viewer->drawable->image->file_name));
+  datasave.data.data_xfer.w         = message->data.data_xfer.w;
+  datasave.data.data_xfer.i         = message->data.data_xfer.i;
+  datasave.data.data_xfer.pos.x     = message->data.data_xfer.pos.x;
+  datasave.data.data_xfer.pos.y     = message->data.data_xfer.pos.y;
+  datasave.data.data_xfer.est_size  = GLOBALS.clipboard_viewer->drawable->image->display.file_size;
+  datasave.data.data_xfer.file_type = file_type;
+  strcpy(datasave.data.data_xfer.file_name,
+      str_leaf(GLOBALS.clipboard_viewer->drawable->image->file_name));
 
-    datasave.your_ref = message->my_ref;
-    datasave.action = message_DATA_SAVE;
+  datasave.your_ref = message->my_ref;
+  datasave.action = message_DATA_SAVE;
 
-    datasave.size = wimp_SIZEOF_MESSAGE_HEADER((
-          offsetof(wimp_message_data_xfer, file_name) +
-          strlen(datasave.data.data_xfer.file_name) + 1 + 3) & ~3);
+  datasave.size = wimp_SIZEOF_MESSAGE_HEADER((
+        offsetof(wimp_message_data_xfer, file_name) +
+        strlen(datasave.data.data_xfer.file_name) + 1 + 3) & ~3);
 
-    wimp_send_message(wimp_USER_MESSAGE_RECORDED,
-        &datasave,
-        message->sender);
-  }
+  wimp_send_message(wimp_USER_MESSAGE_RECORDED,
+                   &datasave,
+                    message->sender);
 
   return event_HANDLED;
+
+#undef data_request_END_OF_LIST
 }
 
 /* ----------------------------------------------------------------------- */
@@ -127,12 +130,11 @@ void clipboard_claim(wimp_w w)
 {
   wimp_message message;
 
-  /* We always broadcast this, even if we already own the clipboard (see
-   * RISCOS Ltd. Clipboard TechNote). */
-
-  /* Claim the clipboard, even if we already own it */
+  /* Claim the clipboard, even if we already own it. We always broadcast
+   * this even if we already own the clipboard (see RISCOS Ltd. Clipboard
+   * TechNote). */
   message.size     = sizeof(wimp_full_message_claim_entity);
-  message.your_ref = 0;
+  message.your_ref = 0; /* not a reply */
   message.action   = message_CLAIM_ENTITY;
   message.data.claim_entity.flags = wimp_CLAIM_CLIPBOARD;
   wimp_send_message(wimp_USER_MESSAGE, &message, wimp_BROADCAST);

--- a/apps/PrivateEye/!PrivatEye/dataxfer.c
+++ b/apps/PrivateEye/!PrivatEye/dataxfer.c
@@ -269,7 +269,8 @@ static int message_data_load(wimp_message *message, void *handle)
                   message->data.data_xfer.file_name,
                   load_addr,
                   exec_addr,
-                  unsafe))
+                  unsafe,
+                  FALSE))
   {
     /* report */
     viewer_destroy(viewer);
@@ -334,6 +335,7 @@ static osbool should_load(bits file_type)
 static int message_data_open(wimp_message *message, void *handle)
 {
   viewer_t *viewer;
+  osbool    is_template;
   bits      load_addr;
   bits      exec_addr;
 
@@ -344,6 +346,8 @@ static int message_data_open(wimp_message *message, void *handle)
 
   if (!should_load(message->data.data_xfer.file_type))
     return event_NOT_HANDLED;
+     
+  is_template = (message->data.data_xfer.est_size == -2);
 
   /* acknowledge - even if we fail, we still tried to load it */
   message->your_ref = message->my_ref;
@@ -371,7 +375,8 @@ static int message_data_open(wimp_message *message, void *handle)
                     message->data.data_xfer.file_name,
                     load_addr,
                     exec_addr,
-                    FALSE))
+                    FALSE,
+                    is_template))
     {
       /* report */
       viewer_destroy(viewer);

--- a/apps/PrivateEye/!PrivatEye/dataxfer.c
+++ b/apps/PrivateEye/!PrivatEye/dataxfer.c
@@ -76,8 +76,8 @@ void dataxfer_fin(void)
 
 /* Acknowledge a Message_DataLoad or Message_DataOpen.
  *
- * We send this even if we failed to load a file since we still attempted to
- * load it. */
+ * We send these even if we fail to load a file since we still made an
+ * attempt. */
 static void send_ack(wimp_message *message)
 {
   message->your_ref = message->my_ref;
@@ -122,7 +122,8 @@ static int message_data_save(wimp_message *message, void *handle)
   /* We are - respond with Message_DataSaveAck. */
   strcpy(message->data.data_xfer.file_name, "<Wimp$Scrap>");
  
-  /* Let the sender know that the data is not "secure" (won't be saved to disc.) */
+  /* Let the sender know that the data is "unsafe" (app-to-app, not
+   * permanently saved.) */
   message->data.data_xfer.est_size = -1; 
 
   message->size     = wimp_SIZEOF_MESSAGE_HEADER((
@@ -155,9 +156,9 @@ static int message_data_save_ack(wimp_message *message, void *handle)
       return event_NOT_HANDLED;
   }
 
-  /* If it's an unsafe transfer (i.e. app-to-app) then tell viewer_save() to
-   * NOT change the image's filename. We don't trust est_size here in case
-   * bad apps don't set it correctly, so check the file_name too. */
+  /* If it's an "unsafe" transfer (i.e. app-to-app) then tell viewer_save()
+   * to NOT change the image's filename. We don't trust est_size here in case
+   * bad apps don't set it to -1 as required, so check the file_name too. */
   unsafe = (message->data.data_xfer.est_size == -1) ||
            (strcmp(message->data.data_xfer.file_name, "<Wimp$Scrap>") == 0);
 

--- a/apps/PrivateEye/!PrivatEye/dataxfer.c
+++ b/apps/PrivateEye/!PrivatEye/dataxfer.c
@@ -155,9 +155,11 @@ static int message_data_save_ack(wimp_message *message, void *handle)
       return event_NOT_HANDLED;
   }
 
-  /* If it's an unsafe transfer (i.e. app-to-app) then tell viewer_save to
-   * not update the image's filename. */
-  unsafe = (message->data.data_xfer.est_size == -1);
+  /* If it's an unsafe transfer (i.e. app-to-app) then tell viewer_save() to
+   * NOT change the image's filename. We don't trust est_size here in case
+   * bad apps don't set it correctly, so check the file_name too. */
+  unsafe = (message->data.data_xfer.est_size == -1) ||
+           (strcmp(message->data.data_xfer.file_name, "<Wimp$Scrap>") == 0);
 
   /* Write the file. */
   if (viewer_save(viewer, message->data.data_xfer.file_name, unsafe))

--- a/apps/PrivateEye/!PrivatEye/dataxfer.c
+++ b/apps/PrivateEye/!PrivatEye/dataxfer.c
@@ -152,8 +152,7 @@ static int message_data_save_ack(wimp_message *message, void *handle)
   message->action   = message_DATA_LOAD;
   wimp_send_message(wimp_USER_MESSAGE_RECORDED, message, message->sender);
 
-  if (save_should_close_menu())
-    wimp_create_menu(wimp_CLOSE_MENU, 0, 0);
+  save_done(); /* closes the dialogue if required */
 
   return event_HANDLED;
 }

--- a/apps/PrivateEye/!PrivatEye/display.c
+++ b/apps/PrivateEye/!PrivatEye/display.c
@@ -689,7 +689,11 @@ static int step(viewer_t *viewer, int direction)
   viewer_unload(viewer);
 
   sprintf(file_name, "%s.%s", dir_name, found_info->name);
-  if (viewer_load(viewer, file_name, found_info->load_addr, found_info->exec_addr))
+  if (viewer_load(viewer,
+                  file_name,
+                  found_info->load_addr,
+                  found_info->exec_addr,
+                  FALSE))
   {
     viewer_destroy(viewer);
     return 0;

--- a/apps/PrivateEye/!PrivatEye/display.c
+++ b/apps/PrivateEye/!PrivatEye/display.c
@@ -697,6 +697,7 @@ static int step(viewer_t *viewer, int direction)
                   file_name,
                   found_info->load_addr,
                   found_info->exec_addr,
+                  FALSE,
                   FALSE))
   {
     viewer_destroy(viewer);

--- a/apps/PrivateEye/!PrivatEye/display.c
+++ b/apps/PrivateEye/!PrivatEye/display.c
@@ -616,6 +616,10 @@ static int step(viewer_t *viewer, int direction)
   else
     direction = -1;
 
+  /* Need a filename to step */
+  if (viewer->drawable->image->file_name[0] == '\0')
+    return 0;
+
   leaf_name = str_leaf(viewer->drawable->image->file_name);
   dir_name  = str_branch(viewer->drawable->image->file_name);
 
@@ -887,11 +891,13 @@ static int display_event_close_window_request(wimp_event_no event_no,
    */
 
   if (pointer.buttons & wimp_CLICK_ADJUST)
+  if (viewer->drawable->image->file_name[0] != '\0')
   {
     filer_open_dir(viewer->drawable->image->file_name);
 
     if (inkey(INKEY_SHIFT))
       return event_HANDLED;
+    }
   }
 
   if (viewer_query_unload(viewer))
@@ -1524,6 +1530,9 @@ static void action_kill(viewer_t *viewer)
   const char       *branch;
   const char       *leaf;
   fileraction_flags flags;
+
+  if (viewer->drawable->image->file_name[0] == '\0')
+    return;
 
   e = EC(xwimp_start_task("Filer_Action", &act));
   if (e)

--- a/apps/PrivateEye/!PrivatEye/eye.c
+++ b/apps/PrivateEye/!PrivatEye/eye.c
@@ -449,7 +449,7 @@ int main(int argc, char *argv[])
       err = viewer_create(&viewer); /* reports any failures itself */
       if (err == result_OK)
       {
-        if (viewer_load(viewer, argv[argc], load_addr, exec_addr))
+        if (viewer_load(viewer, argv[argc], load_addr, exec_addr, FALSE))
           viewer_destroy(viewer);
         else
           viewer_open(viewer);

--- a/apps/PrivateEye/!PrivatEye/eye.c
+++ b/apps/PrivateEye/!PrivatEye/eye.c
@@ -449,7 +449,7 @@ int main(int argc, char *argv[])
       err = viewer_create(&viewer); /* reports any failures itself */
       if (err == result_OK)
       {
-        if (viewer_load(viewer, argv[argc], load_addr, exec_addr, FALSE))
+        if (viewer_load(viewer, argv[argc], load_addr, exec_addr, FALSE, FALSE))
           viewer_destroy(viewer);
         else
           viewer_open(viewer);

--- a/apps/PrivateEye/!PrivatEye/save.c
+++ b/apps/PrivateEye/!PrivatEye/save.c
@@ -32,11 +32,7 @@ static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
 
   NOT_USED(opaque);
 
-  saving_viewer = GLOBALS.current_viewer;
-  if (saving_viewer == NULL)
-    return;
-
-  image = saving_viewer->drawable->image;
+  image = GLOBALS.current_viewer->drawable->image;
   if (image->file_name[0] != '\0')
     file_name = image->file_name;
   else
@@ -47,13 +43,15 @@ static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
                    image->display.file_size);
 }
 
+/* This only catches the case of <F3><Esc>. If the save dialogue is opened as
+ * a submenu then the owner will need to call viewer_savedlg_reset(). */
 static int viewer_savedlg_message_menus_deleted(wimp_message *message,
                                                 void         *handle)
 {
   NOT_USED(message);
   NOT_USED(handle);
 
-  viewer_savedlg = NULL;
+  saving_viewer = NULL;
 
   return event_HANDLED;
 }
@@ -65,8 +63,7 @@ static void viewer_savedlg_save_handler(dialogue_t *d, const char *file_name)
 {
   NOT_USED(d);
 
-  if (saving_viewer)
-    viewer_save(saving_viewer, file_name, FALSE);
+  viewer_save(GLOBALS.current_viewer, file_name, FALSE);
 }
 
 /* Called on drag saves with the ref of the DataSave message. */
@@ -74,8 +71,8 @@ static void viewer_savedlg_dataxfer_handler(dialogue_t *d, int my_ref)
 {
   NOT_USED(d);
 
-  if (saving_viewer)
-    saving_viewer->drawable->image->last_save_ref = my_ref;
+  saving_viewer = GLOBALS.current_viewer;
+  saving_viewer->drawable->image->last_save_ref = my_ref;
 }
 
 /* ----------------------------------------------------------------------- */
@@ -83,6 +80,11 @@ static void viewer_savedlg_dataxfer_handler(dialogue_t *d, int my_ref)
 viewer_t *viewer_savedlg_get(void)
 {
   return saving_viewer;
+}
+
+void viewer_savedlg_reset(void)
+{
+  saving_viewer = NULL;
 }
 
 /* ----------------------------------------------------------------------- */

--- a/apps/PrivateEye/!PrivatEye/save.c
+++ b/apps/PrivateEye/!PrivatEye/save.c
@@ -37,6 +37,7 @@ static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
   image = saving_viewer->drawable->image;
   save_set_file_name(d, image->file_name);
   save_set_file_type(d, image->display.file_type);
+  save_set_file_size(d, image->display.file_size);
 }
 
 /* Called on 'Save' button clicks, but not on drag saves. */
@@ -46,7 +47,7 @@ static void viewer_savedlg_handler(dialogue_t *d, const char *file_name)
 
   if (saving_viewer)
   {
-    viewer_save(saving_viewer, file_name);
+    viewer_save(saving_viewer, file_name, FALSE);
     viewer_savedlg_completed();
   }
 }

--- a/apps/PrivateEye/!PrivatEye/save.c
+++ b/apps/PrivateEye/!PrivatEye/save.c
@@ -19,21 +19,22 @@
 
 dialogue_t *viewer_savedlg;
 
+static viewer_t *saving_viewer;
+
 /* ----------------------------------------------------------------------- */
 
+/* Save dialogue was opened for whatever reason. */
 static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
 {
-  viewer_t *viewer;
-  image_t  *image;
+  image_t *image;
 
   NOT_USED(opaque);
 
-  viewer = GLOBALS.current_viewer;
-  if (viewer == NULL)
+  saving_viewer = GLOBALS.current_viewer;
+  if (saving_viewer == NULL)
     return;
 
-  image = viewer->drawable->image;
-
+  image = saving_viewer->drawable->image;
   save_set_file_name(d, image->file_name);
   save_set_file_type(d, image->display.file_type);
 }
@@ -41,15 +42,25 @@ static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
 /* Called on 'Save' button clicks, but not on drag saves. */
 static void viewer_savedlg_handler(dialogue_t *d, const char *file_name)
 {
-  viewer_t *viewer;
-
   NOT_USED(d);
 
-  viewer = GLOBALS.current_viewer;
-  if (viewer == NULL)
-    return;
+  if (saving_viewer)
+  {
+    viewer_save(saving_viewer, file_name);
+    viewer_savedlg_completed();
+  }
+}
 
-  viewer_save(viewer, file_name);
+/* ----------------------------------------------------------------------- */
+
+viewer_t *viewer_savedlg_get(void)
+{
+  return saving_viewer;
+}
+
+void viewer_savedlg_completed(void)
+{
+  saving_viewer = NULL;
 }
 
 /* ----------------------------------------------------------------------- */

--- a/apps/PrivateEye/!PrivatEye/save.c
+++ b/apps/PrivateEye/!PrivatEye/save.c
@@ -47,16 +47,26 @@ static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
                    image->display.file_size);
 }
 
+static int viewer_savedlg_message_menus_deleted(wimp_message *message,
+                                                void         *handle)
+{
+  NOT_USED(message);
+  NOT_USED(handle);
+
+  viewer_savedlg = NULL;
+
+  return event_HANDLED;
+}
+
+/* ----------------------------------------------------------------------- */
+
 /* Called on 'Save' button clicks, but not on drag saves. */
 static void viewer_savedlg_save_handler(dialogue_t *d, const char *file_name)
 {
   NOT_USED(d);
 
   if (saving_viewer)
-  {
     viewer_save(saving_viewer, file_name, FALSE);
-    viewer_savedlg_completed();
-  }
 }
 
 /* Called on drag saves with the ref of the DataSave message. */
@@ -65,9 +75,7 @@ static void viewer_savedlg_dataxfer_handler(dialogue_t *d, int my_ref)
   NOT_USED(d);
 
   if (saving_viewer)
-  {
     saving_viewer->drawable->image->last_save_ref = my_ref;
-  }
 }
 
 /* ----------------------------------------------------------------------- */
@@ -75,11 +83,6 @@ static void viewer_savedlg_dataxfer_handler(dialogue_t *d, int my_ref)
 viewer_t *viewer_savedlg_get(void)
 {
   return saving_viewer;
-}
-
-void viewer_savedlg_completed(void)
-{
-  saving_viewer = NULL;
 }
 
 /* ----------------------------------------------------------------------- */
@@ -91,6 +94,9 @@ result_t viewer_savedlg_init(void)
     return result_OOM;
 
   dialogue_set_fillout_handler(viewer_savedlg, viewer_savedlg_fillout, NULL);
+  dialogue_set_menus_deleted_handler(viewer_savedlg,
+                                     viewer_savedlg_message_menus_deleted);
+
   save_set_dataxfer_handler(viewer_savedlg, viewer_savedlg_dataxfer_handler);
   save_set_save_handler(viewer_savedlg, viewer_savedlg_save_handler);
 

--- a/apps/PrivateEye/!PrivatEye/save.c
+++ b/apps/PrivateEye/!PrivatEye/save.c
@@ -7,6 +7,7 @@
 
 #include "oslib/types.h"
 
+#include "appengine/base/messages.h"
 #include "appengine/dialogues/save.h"
 #include "appengine/wimp/dialogue.h"
 
@@ -26,7 +27,8 @@ static viewer_t *saving_viewer;
 /* Save dialogue was opened for whatever reason. */
 static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
 {
-  image_t *image;
+  image_t    *image;
+  const char *file_name;
 
   NOT_USED(opaque);
 
@@ -35,7 +37,13 @@ static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
     return;
 
   image = saving_viewer->drawable->image;
-  save_set_file_name(d, image->file_name);
+  if (image->file_name[0] != '\0')
+    file_name = image->file_name;
+  else
+    file_name = message0("untitled.filename");
+
+  // should merge these set methods together
+  save_set_file_name(d, file_name);
   save_set_file_type(d, image->display.file_type);
   save_set_file_size(d, image->display.file_size);
 }

--- a/apps/PrivateEye/!PrivatEye/save.c
+++ b/apps/PrivateEye/!PrivatEye/save.c
@@ -42,14 +42,13 @@ static void viewer_savedlg_fillout(dialogue_t *d, void *opaque)
   else
     file_name = message0("untitled.filename");
 
-  // should merge these set methods together
-  save_set_file_name(d, file_name);
-  save_set_file_type(d, image->display.file_type);
-  save_set_file_size(d, image->display.file_size);
+  save_set_info(d, file_name,
+                   image->display.file_type,
+                   image->display.file_size);
 }
 
 /* Called on 'Save' button clicks, but not on drag saves. */
-static void viewer_savedlg_handler(dialogue_t *d, const char *file_name)
+static void viewer_savedlg_save_handler(dialogue_t *d, const char *file_name)
 {
   NOT_USED(d);
 
@@ -57,6 +56,17 @@ static void viewer_savedlg_handler(dialogue_t *d, const char *file_name)
   {
     viewer_save(saving_viewer, file_name, FALSE);
     viewer_savedlg_completed();
+  }
+}
+
+/* Called on drag saves with the ref of the DataSave message. */
+static void viewer_savedlg_dataxfer_handler(dialogue_t *d, int my_ref)
+{
+  NOT_USED(d);
+
+  if (saving_viewer)
+  {
+    saving_viewer->drawable->image->last_save_ref = my_ref;
   }
 }
 
@@ -81,7 +91,8 @@ result_t viewer_savedlg_init(void)
     return result_OOM;
 
   dialogue_set_fillout_handler(viewer_savedlg, viewer_savedlg_fillout, NULL);
-  save_set_save_handler(viewer_savedlg, viewer_savedlg_handler);
+  save_set_dataxfer_handler(viewer_savedlg, viewer_savedlg_dataxfer_handler);
+  save_set_save_handler(viewer_savedlg, viewer_savedlg_save_handler);
 
   return result_OK;
 }

--- a/apps/PrivateEye/!PrivatEye/save.h
+++ b/apps/PrivateEye/!PrivatEye/save.h
@@ -9,7 +9,13 @@
 #include "appengine/wimp/dialogue.h"
 #include "appengine/base/errors.h"
 
-extern dialogue_t *viewer_savedlg;
+#include "viewer.h"
+
+extern dialogue_t *viewer_savedlg; // exposed for dialogue_get_window use
+
+viewer_t *viewer_savedlg_get(void);
+/* Call when a save is complete so that savedlg resets. */
+void viewer_savedlg_completed(void);
 
 result_t viewer_savedlg_init(void);
 void viewer_savedlg_fin(void);

--- a/apps/PrivateEye/!PrivatEye/save.h
+++ b/apps/PrivateEye/!PrivatEye/save.h
@@ -14,8 +14,8 @@
 extern dialogue_t *viewer_savedlg; // exposed for dialogue_get_window use
 
 viewer_t *viewer_savedlg_get(void);
-/* Call when a save is complete so that savedlg resets. */
-void viewer_savedlg_completed(void);
+/* Call when the savedlg is closed. */
+void viewer_savedlg_reset(void);
 
 result_t viewer_savedlg_init(void);
 void viewer_savedlg_fin(void);

--- a/apps/PrivateEye/!PrivatEye/tags.c
+++ b/apps/PrivateEye/!PrivatEye/tags.c
@@ -240,7 +240,7 @@ static void tags_image_changed_callback(image_t             *image,
   switch (change)
   {
   case imageobserver_CHANGE_GAINED_FOCUS:
-    if (LOCALS.image != image)
+    if (LOCALS.image != image && image->file_name[0] != '\0')
     {
       char        scratch[32];
       const char *leaf;

--- a/apps/PrivateEye/!PrivatEye/viewer.c
+++ b/apps/PrivateEye/!PrivatEye/viewer.c
@@ -829,7 +829,8 @@ osbool viewer_load(viewer_t   *viewer,
                    const char *file_name,
                    bits        load,
                    bits        exec,
-                   osbool      unsafe)
+                   osbool      unsafe,
+                   osbool      template)
 {
   result_t    err;
   image_t    *image = NULL;
@@ -868,12 +869,15 @@ osbool viewer_load(viewer_t   *viewer,
     }
   }
 
+  if (unsafe)
+    image->flags |= image_FLAG_MODIFIED;
+
+  if (template)
+    strcpy(image->file_name, str_leaf(file_name));
+
   err = drawable_create(image, &drawable);
   if (err)
     goto Failure;
-
-  if (unsafe)
-    image->flags |= image_FLAG_MODIFIED;
 
   viewer->image    = image;
   viewer->drawable = drawable;

--- a/apps/PrivateEye/!PrivatEye/viewer.c
+++ b/apps/PrivateEye/!PrivatEye/viewer.c
@@ -56,9 +56,12 @@ static void update_viewer_title(viewer_t *viewer)
   char buf[256];
   int  nclones;
 
-  sprintf(file_name, "%.*s",
-    (int) sizeof(file_name),
-          viewer->image->file_name);
+  if (viewer->image->file_name[0] != '\0')
+    sprintf(file_name, "%.*s",
+      (int) sizeof(file_name),
+            viewer->image->file_name);
+  else
+    strcpy(file_name, message0("untitled.title"));
   sprintf(percentage, "%d%%", viewer->scale.cur);
   sprintf(buf, message0("display.title"), file_name, percentage);
 
@@ -856,7 +859,8 @@ osbool viewer_load(viewer_t   *viewer,
 
     image = image_create_from_file(&GLOBALS.choices.image,
                                     file_name,
-                                    (load >> 8) & 0xfff);
+                                    (load >> 8) & 0xfff,
+                                    unsafe);
     if (image == NULL)
     {
       err = result_OOM;

--- a/apps/PrivateEye/!PrivatEye/viewer.h
+++ b/apps/PrivateEye/!PrivatEye/viewer.h
@@ -111,12 +111,13 @@ void viewer_open(viewer_t *viewer);
 osbool viewer_load(viewer_t   *viewer,
                    const char *file_name,
                    bits        load,
-                   bits        exec);
+                   bits        exec,
+                   osbool      unsafe);
 void viewer_unload(viewer_t *viewer);
 
 int viewer_query_unload(viewer_t *viewer);
 
-osbool viewer_save(viewer_t *viewer, const char *file_name);
+osbool viewer_save(viewer_t *viewer, const char *file_name, osbool unsafe);
 
 void viewer_clone(viewer_t *viewer);
 result_t viewer_clone_from_window(wimp_w w, viewer_t **new_viewer);

--- a/apps/PrivateEye/!PrivatEye/viewer.h
+++ b/apps/PrivateEye/!PrivatEye/viewer.h
@@ -112,7 +112,8 @@ osbool viewer_load(viewer_t   *viewer,
                    const char *file_name,
                    bits        load,
                    bits        exec,
-                   osbool      unsafe);
+                   osbool      unsafe,
+                   osbool      template);
 void viewer_unload(viewer_t *viewer);
 
 int viewer_query_unload(viewer_t *viewer);

--- a/libs/appengine/dialogues/save.h
+++ b/libs/appengine/dialogues/save.h
@@ -15,10 +15,16 @@
 dialogue_t *save_create(void);
 void save_destroy(dialogue_t *d);
 
-result_t save_set_file_name(dialogue_t *d, const char *file_name);
-void save_set_file_type(dialogue_t *d, bits file_type);
-void save_set_file_size(dialogue_t *d, size_t bytes);
+result_t save_set_info(dialogue_t *d,
+                 const char       *file_name,
+                       bits        file_type,
+                       size_t      bytes);
 
+/* Called for data transfer saves, i.e. icon dragged to directory display */
+typedef void (save_dataxfer_handler)(dialogue_t *d, int my_ref);
+void save_set_dataxfer_handler(dialogue_t *d, save_dataxfer_handler *handler);
+
+/* Called for direct saves, i.e. dialogue 'Save' button is clicked */
 typedef void (save_save_handler)(dialogue_t *d, const char *file_name);
 void save_set_save_handler(dialogue_t *d, save_save_handler *handler);
 

--- a/libs/appengine/dialogues/save.h
+++ b/libs/appengine/dialogues/save.h
@@ -28,6 +28,6 @@ void save_set_dataxfer_handler(dialogue_t *d, save_dataxfer_handler *handler);
 typedef void (save_save_handler)(dialogue_t *d, const char *file_name);
 void save_set_save_handler(dialogue_t *d, save_save_handler *handler);
 
-int save_should_close_menu(void);
+void save_done(void);
 
 #endif /* APPENGINE_DIALOGUE_SAVE_H */

--- a/libs/appengine/dialogues/save.h
+++ b/libs/appengine/dialogues/save.h
@@ -17,6 +17,7 @@ void save_destroy(dialogue_t *d);
 
 result_t save_set_file_name(dialogue_t *d, const char *file_name);
 void save_set_file_type(dialogue_t *d, bits file_type);
+void save_set_file_size(dialogue_t *d, size_t bytes);
 
 typedef void (save_save_handler)(dialogue_t *d, const char *file_name);
 void save_set_save_handler(dialogue_t *d, save_save_handler *handler);

--- a/libs/appengine/dialogues/save/save.c
+++ b/libs/appengine/dialogues/save/save.c
@@ -283,7 +283,8 @@ void save_set_save_handler(dialogue_t *d, save_save_handler *save_handler)
 
 /* ----------------------------------------------------------------------- */
 
-int save_should_close_menu(void)
+void save_done(void)
 {
-  return saving_close_menu & wimp_DRAG_SELECT;
+  if (saving_close_menu & wimp_DRAG_SELECT)
+    wimp_create_menu(wimp_CLOSE_MENU, 0, 0);
 }

--- a/libs/appengine/dialogues/save/save.c
+++ b/libs/appengine/dialogues/save/save.c
@@ -286,5 +286,8 @@ void save_set_save_handler(dialogue_t *d, save_save_handler *save_handler)
 void save_done(void)
 {
   if (saving_close_menu & wimp_DRAG_SELECT)
+  {
     wimp_create_menu(wimp_CLOSE_MENU, 0, 0);
+    saving_close_menu = 0;
+  }
 }

--- a/libs/appengine/dialogues/save/save.c
+++ b/libs/appengine/dialogues/save/save.c
@@ -45,6 +45,7 @@ typedef struct save_t
   dialogue_t         dialogue; /* base class */
   char              *file_name;
   bits               file_type;
+  size_t             est_size;
   save_save_handler *save_handler;
 }
 save_t;
@@ -212,11 +213,11 @@ static int save_event_user_drag_box(wimp_event_no event_no,
   message.data.data_xfer.i         = pointer.i;
   message.data.data_xfer.pos.x     = pointer.pos.x;
   message.data.data_xfer.pos.y     = pointer.pos.y;
-  message.data.data_xfer.est_size  = -1; /* unsafe */
+  message.data.data_xfer.est_size  = s->est_size;
   message.data.data_xfer.file_type = s->file_type;
   strcpy(message.data.data_xfer.file_name, str_leaf(file_name));
 
-  message.your_ref = 0;
+  message.your_ref = 0; /* not a reply */
   message.action = message_DATA_SAVE;
 
   message.size = wimp_SIZEOF_MESSAGE_HEADER((
@@ -267,6 +268,13 @@ void save_set_file_type(dialogue_t *d, bits file_type)
   file_type_to_sprite_name(file_type, sprname);
 
   icon_validation_printf(w, SAVE_I_ICON, "Ni_icon;S%s", sprname);
+}
+
+void save_set_file_size(dialogue_t *d, size_t bytes)
+{
+  save_t *s = (save_t *) d;
+
+  s->est_size = bytes;
 }
 
 void save_set_save_handler(dialogue_t *d, save_save_handler *save_handler)

--- a/libs/appengine/gadgets/effects/effects.c
+++ b/libs/appengine/gadgets/effects/effects.c
@@ -2097,6 +2097,7 @@ static void effects_cancel(effectswin_t *ew)
 
 /* ----------------------------------------------------------------------- */
 
+// todo: factor this out to imageobwin
 // todo: check cleanup paths
 static result_t effectswin_create(effectswin_t   **new_ew,
                             const effectsconfig_t *config,
@@ -2105,7 +2106,8 @@ static result_t effectswin_create(effectswin_t   **new_ew,
   result_t      err;
   effectswin_t *ew = NULL;
   wimp_w        w  = wimp_ICON_BAR;
-  char          scratch[32];
+  char          token[32];
+  char          format[32];
   const char   *leaf;
   char          title[256];
 
@@ -2128,9 +2130,13 @@ static result_t effectswin_create(effectswin_t   **new_ew,
 
   /* set its title, including the leafname of the image */
 
-  sprintf(scratch, "%s.title", "effect");
-  leaf = str_leaf(image->file_name);
-  sprintf(title, message0(scratch), leaf);
+  sprintf(token, "%s.title", "effect");
+  strcpy(format, message0(token));
+  if (image->file_name[0] != '\0')
+    leaf = str_leaf(image->file_name);
+  else
+    leaf = message0("untitled.title");
+  sprintf(title, format, leaf);
   window_set_title_text(w, title);
 
   ew->window = w;

--- a/libs/appengine/gadgets/imageobwin/imageobwin.c
+++ b/libs/appengine/gadgets/imageobwin/imageobwin.c
@@ -127,7 +127,7 @@ result_t imageobwin_construct(imageobwin_factory_t *factory,
                               event_wimp_handler   *menu)
 {
   result_t err;
-  char     scratch[32]; /* Careful Now */
+  char     token[32]; /* Careful Now */
   size_t   len;
 
   /* initialise member(s) used in error cleanup */
@@ -146,8 +146,8 @@ result_t imageobwin_construct(imageobwin_factory_t *factory,
 
   if (menu)
   {
-    sprintf(scratch, "menu.%s", name);
-    factory->menu = menu_create_from_desc(message0(scratch));
+    sprintf(token, "menu.%s", name);
+    factory->menu = menu_create_from_desc(message0(token));
     if (factory->menu == NULL)
     {
       err = result_OOM;
@@ -232,7 +232,8 @@ static result_t imageobwin_new(imageobwin_factory_t *factory,
 {
   result_t      err;
   imageobwin_t *obwin;
-  char          scratch[32];
+  char          token[32];
+  char          format[32];
   const char   *leaf;
   char          title[256];
 
@@ -259,9 +260,13 @@ static result_t imageobwin_new(imageobwin_factory_t *factory,
 
   /* set its title, including the leafname of the image */
 
-  sprintf(scratch, "%s.title", factory->name);
-  leaf = str_leaf(image->file_name);
-  sprintf(title, message0(scratch), leaf);
+  sprintf(token, "%s.title", factory->name);
+  strcpy(format, message0(token));
+  if (image->file_name[0] != '\0')
+    leaf = str_leaf(image->file_name);
+  else
+    leaf = message0("untitled.title");
+  sprintf(title, format, leaf);
   window_set_title_text(obwin->w, title);
 
   /* fill out */

--- a/libs/appengine/graphics/image-observer.h
+++ b/libs/appengine/graphics/image-observer.h
@@ -19,6 +19,8 @@ enum
   imageobserver_CHANGE_ABOUT_TO_MODIFY,
   imageobserver_CHANGE_MODIFIED,
 
+  imageobserver_CHANGE_SAVED,            /**< When image safely saved to disc */
+
   imageobserver_CHANGE_HIDDEN,
   imageobserver_CHANGE_REVEALED,
 

--- a/libs/appengine/graphics/image.h
+++ b/libs/appengine/graphics/image.h
@@ -191,7 +191,7 @@ struct T
 
   void         *image;
 
-  char          file_name[256]; /* careful now */
+  char          file_name[256]; /* NUL for no file name */
   unsigned char digest[image_DIGESTSZ];
 
   imageinfo     info;
@@ -237,7 +237,8 @@ T *image_create(void);
 /* Creates and loads the specified filename. */
 T *image_create_from_file(image_choices *choices,
                           const char    *file_name,
-                          bits           file_type);
+                          bits           file_type,
+                          osbool         unsafe);
 
 void image_destroy(T *image);
 

--- a/libs/appengine/graphics/image.h
+++ b/libs/appengine/graphics/image.h
@@ -76,7 +76,7 @@ enum
   image_FLAG_COLOUR     = 1 << 1,  /* is a colour image (otherwise mono) */
   image_FLAG_HAS_MASK   = 1 << 2,  /* has sprite-style binary mask */
   image_FLAG_EDITING    = 1 << 3,  /* is currently being edited */
-  image_FLAG_MODIFIED   = 1 << 4,  /* is modified */
+  image_FLAG_MODIFIED   = 1 << 4,  /* is modified or unsaved (reset on saves) */
   image_FLAG_CAN_HIST   = 1 << 5,  /* can obtain histogram */
   image_FLAG_CAN_ROT    = 1 << 6,  /* can rotate */
   image_FLAG_HAS_META   = 1 << 7,  /* has metadata */
@@ -263,6 +263,9 @@ enum
 typedef unsigned int image_modified_flags;
 
 void image_modified(T *image, image_modified_flags flags);
+
+/** Call this when an image was saved to disc. */
+void image_saved(T *i);
 
 /* ----------------------------------------------------------------------- */
 

--- a/libs/appengine/graphics/image.h
+++ b/libs/appengine/graphics/image.h
@@ -194,6 +194,8 @@ struct T
   char          file_name[256]; /* NUL for no file name */
   unsigned char digest[image_DIGESTSZ];
 
+  int           last_save_ref; /* store when we save, zero this on edits */
+
   imageinfo     info;
 
   int           refcount;

--- a/libs/appengine/graphics/image/bitmap.c
+++ b/libs/appengine/graphics/image/bitmap.c
@@ -44,8 +44,6 @@ int bitmap_save(image_choices *choices,
     return TRUE; /* failure */
   }
 
-  image->flags &= ~image_FLAG_MODIFIED;
-
   return FALSE; /* success */
 }
 

--- a/libs/appengine/graphics/image/generic.c
+++ b/libs/appengine/graphics/image/generic.c
@@ -29,7 +29,5 @@ int generic_save(image_choices *choices,
     return TRUE; /* failure */
   }
 
-  image->flags &= ~image_FLAG_MODIFIED;
-
   return FALSE; /* success */
 }

--- a/libs/appengine/graphics/image/image.c
+++ b/libs/appengine/graphics/image/image.c
@@ -268,6 +268,13 @@ void image_modified(image_t *i, image_modified_flags flags)
   imageobserver_event(i, imageobserver_CHANGE_MODIFIED, &data);
 }
 
+void image_saved(image_t *i)
+{
+  i->flags &= ~image_FLAG_MODIFIED;
+
+  imageobserver_event(i, imageobserver_CHANGE_SAVED, NULL);
+}
+
 /* ----------------------------------------------------------------------- */
 
 void image_destroy(image_t *i)

--- a/libs/appengine/graphics/image/image.c
+++ b/libs/appengine/graphics/image/image.c
@@ -265,6 +265,7 @@ void image_modified(image_t *i, image_modified_flags flags)
   imageobserver_data data;
 
   i->flags |= image_FLAG_MODIFIED;
+  i->last_save_ref = 0;
 
   image_dispose_transient(i);
 
@@ -276,6 +277,7 @@ void image_modified(image_t *i, image_modified_flags flags)
 void image_saved(image_t *i)
 {
   i->flags &= ~image_FLAG_MODIFIED;
+  i->last_save_ref = 0; // not sure
 
   imageobserver_event(i, imageobserver_CHANGE_SAVED, NULL);
 }

--- a/libs/appengine/graphics/image/image.c
+++ b/libs/appengine/graphics/image/image.c
@@ -277,7 +277,11 @@ void image_modified(image_t *i, image_modified_flags flags)
 void image_saved(image_t *i)
 {
   i->flags &= ~image_FLAG_MODIFIED;
-  i->last_save_ref = 0; // not sure
+
+  /* TODO: Enter the world of pain that is implementing support for
+   * Message_DataSaved. It's hard to justify the effort since the only other
+   * app that supports it that I can find is Edit, and even that is only
+   * implementing half the protocol. */
 
   imageobserver_event(i, imageobserver_CHANGE_SAVED, NULL);
 }

--- a/libs/appengine/graphics/image/image.c
+++ b/libs/appengine/graphics/image/image.c
@@ -156,7 +156,8 @@ image_t *image_create(void)
 
 image_t *image_create_from_file(image_choices *choices,
                           const char          *file_name,
-                                bits           file_type)
+                                bits           file_type,
+                                osbool         unsafe)
 {
   image_t *i;
 
@@ -164,14 +165,18 @@ image_t *image_create_from_file(image_choices *choices,
   if (i == NULL)
     goto Failure;
 
-  strcpy(i->file_name, file_name);
   i->source.file_type = file_type;
+
+  strcpy(i->file_name, file_name);
 
   if (loader_export_methods(choices, i, file_type))
     goto Failure;
 
   if (i->methods.load(choices, i))
     goto Failure;
+
+  if (unsafe)
+    i->file_name[0] = '\0';
 
   return i;
 

--- a/libs/appengine/wimp/event/event-message.c
+++ b/libs/appengine/wimp/event/event-message.c
@@ -55,7 +55,7 @@ static int event_message(wimp_event_no event_no,
   }
   locs[] =
   {
-    /* note that a many of these offsets are the same... */
+    /* note that many of these offsets are the same... */
 
     { message_DATA_SAVE,     offsetof(wimp_message_data_xfer, w)           },
     { message_DATA_SAVE_ACK, offsetof(wimp_message_data_xfer, w)           },


### PR DESCRIPTION
Properly support app-to-app transfers in the same way that the standard apps do: using "untitled" for files received via scrap transfer, marking them as modified, etc.

Start Message_DataSaved support, but no other beggar properly supports it AFAICT.

Support 'template' mode for Message_DataOpen which only @nemo20000 deeply cares about.
